### PR TITLE
Fix Ember.keys Deprecation

### DIFF
--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -337,7 +337,7 @@ var I18nService = Ember.Service.extend({
   _getActionCallHash: function (actions) {
     var actionsCallHash = {};
 
-    Ember.keys(actions).forEach(function (key) {
+    Object.keys(actions).forEach(function (key) {
       actionsCallHash[key] = actions[key].call();
     });
 


### PR DESCRIPTION
Fix a deprecation related to using Ember.keys instead of Object.keys.