### PR TITLE
Passing (old|new) locale to (pre|post)-init actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ export default Ember.Route.extend(I18nMixin, {
     var i18n = this.get('i18n');
 
     // my-fancy-action is a name that can be used to unregister the action later
-    i18n.registerPostInitAction('my-fancy-action', function () {
+    i18n.registerPostInitAction('my-fancy-action', function (oldLang) {
       // do preloading
     });
   }
@@ -170,6 +170,8 @@ export default Ember.Route.extend(I18nMixin, {
 ```
 
 Pre- or post-init actions may return a promise. If any of the actions returns a promise, the service will wait for the promises to resolve before moving on. If pre-init actions return promises, the service will wait for them to resolve before initializing i18next. If post-init actions return promises, the service will wait for them to resolve before notifying the application about the change in locale.
+
+The new locale is passed as a parameter to pre-init actions and the old locale to post-init actions. These parameters are `undefined` when the the i18n service's `initLibraryAsync` method is called.
 
 Finally, actions may be unregistered using the `unregisterPreInitAction` and `unregisterPostInitAction` methods. To unregister the post-init action from the previous example, you would do the following:
 

--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -145,10 +145,11 @@ var I18nService = Ember.Service.extend({
     }
 
     var self = this;
-    return this._runPreInitActions().then(function () {
+    var oldLang = this._locale;
+    return this._runPreInitActions(lang).then(function () {
       return self._setLng(lang);
     }).then(function () {
-      return self._runPostInitActions();
+      return self._runPostInitActions(oldLang);
     }).then(function () {
       return Ember.RSVP.resolve(lang);
     }).catch(function (reason) {
@@ -334,26 +335,26 @@ var I18nService = Ember.Service.extend({
     });
   },
 
-  _getActionCallHash: function (actions) {
+  _getActionCallHash: function (actions, lang) {
     var actionsCallHash = {};
 
     Object.keys(actions).forEach(function (key) {
-      actionsCallHash[key] = actions[key].call();
+      actionsCallHash[key] = actions[key].call(undefined, lang);
     });
 
     return actionsCallHash;
   },
 
-  _runPreInitActions: function () {
+  _runPreInitActions: function (newLang) {
     var _preInitActions = this.get('_preInitActions');
-    var actionCalls = this._getActionCallHash(_preInitActions);
+    var actionCalls = this._getActionCallHash(_preInitActions, newLang);
 
     return Ember.RSVP.hash(actionCalls, 'ember-i18next: pre init actions');
   },
 
-  _runPostInitActions: function () {
+  _runPostInitActions: function (oldLang) {
     var _postInitActions = this.get('_postInitActions');
-    var actionCalls = this._getActionCallHash(_postInitActions);
+    var actionCalls = this._getActionCallHash(_postInitActions, oldLang);
 
     return Ember.RSVP.hash(actionCalls, 'ember-i18next: post init actions');
   }

--- a/tests/acceptance/service-init-actions-test.js
+++ b/tests/acceptance/service-init-actions-test.js
@@ -20,20 +20,22 @@ module('Acceptance: ServiceInitActions', {
 });
 
 test('pre-init actions', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  service.registerPreInitAction('test-pre-init', function () {
+  service.registerPreInitAction('test-pre-init', function (newLang) {
     assert.ok(true, 'Service calls pre-init actions on initLibraryAsync');
+    assert.strictEqual(typeof newLang, 'undefined', 'Pre-init\'s newLang param is undefined on initLibraryAsync');
   });
 
   visit('/test-init');
 });
 
 test('post-init actions', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  service.registerPostInitAction('test-post-init', function () {
+  service.registerPostInitAction('test-post-init', function (oldLang) {
     assert.ok(true, 'Service calls post-init actions on initLibraryAsync');
+    assert.strictEqual(typeof oldLang, 'undefined', 'Post-init\'s oldLang param is undefined on initLibraryAsync');
   });
 
   visit('/test-init');

--- a/tests/acceptance/service-locale-change-actions-test.js
+++ b/tests/acceptance/service-locale-change-actions-test.js
@@ -20,14 +20,15 @@ module('Acceptance: ServiceLocaleChangeActions', {
 });
 
 test('setting language triggers pre-init actions', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   visit('/');
   click('a#change-language-en');
 
   andThen(function() {
-    service.registerPreInitAction('test-pre-init', function () {
+    service.registerPreInitAction('test-pre-init', function (newLang) {
       assert.ok(true, 'Setting locale triggers pre-init action');
+      assert.strictEqual(newLang, 'th', 'Pre-init\'s newLang is "th"');
     });
   });
 
@@ -35,14 +36,15 @@ test('setting language triggers pre-init actions', function (assert) {
 });
 
 test('setting language triggers post-init actions', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   visit('/');
   click('a#change-language-en');
 
   andThen(function () {
-    service.registerPostInitAction('test-post-init', function () {
+    service.registerPostInitAction('test-post-init', function (oldLang) {
       assert.ok(true, 'Setting locale triggers post-init action');
+      assert.strictEqual(oldLang, 'en', 'Post-init\'s oldLang is "en"');
     });
   });
 


### PR DESCRIPTION
It would be interesting to have access to the new locale when running pre-init actions, and the old local when running post-init actions. So actions can be executed according to this locale value.

The new locale is passed as a parameter to pre-init actions and the old one to post-init actions. Old or new locale is `undefined` when the i18n service's `initLibraryAsync` method is called.