### PR TITLE
Specify i18next version

### DIFF
--- a/blueprints/ember-i18next/index.js
+++ b/blueprints/ember-i18next/index.js
@@ -4,6 +4,6 @@ module.exports = {
   normalizeEntityName: function () {},
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('i18next');
+    return this.addBowerPackageToProject('i18next', '^1.7.0');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "i18next": "^1.7.0",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.18",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "i18next": "~1.7.0",
+    "i18next": "^1.7.0",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"


### PR DESCRIPTION
Add a version string to the call to `addBowerpackageToProject` to ensure i18next 2.x is not installed. Should fix #25.