### PR TITLE
Bump i18next version to v3 and update api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can access your app's translations in templates using the `t` helper:
 <button type="button">{{t 'button.text'}}</button>
 ```
 
-Pass values to be interpolated into the translation as [hash arguments](http://handlebarsjs.com/expressions.html). For example, for a translation that includes an interpolated `__count__` value:
+Pass values to be interpolated into the translation as [hash arguments](http://handlebarsjs.com/expressions.html). For example, for a translation that includes an interpolated `{{count}}` value:
 
 ```handlebars
 <div>{{t 'messages.count' count=3}}</div>

--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -280,10 +280,10 @@ var I18nService = Ember.Service.extend({
       i18next
         .use(window.i18nextXHRBackend)
         .init(options, (err, t) => {
-         if ( err ) {
-           reject( err );
+         if (err) {
+           reject(err);
          } else {
-           resolve( i18next );
+           resolve(i18next);
          }
       });
     });

--- a/blueprints/ember-i18next/index.js
+++ b/blueprints/ember-i18next/index.js
@@ -4,6 +4,9 @@ module.exports = {
   normalizeEntityName: function () {},
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('i18next', '^1.7.0');
+    return this.addBowerPackagesToProject([
+                  {name:'i18next-xhr-backend', target:'^0.6.0'},
+                  {name:'i18next', target:'^3.3.1'}
+                ]);
   }
 };

--- a/blueprints/ember-i18next/index.js
+++ b/blueprints/ember-i18next/index.js
@@ -5,8 +5,8 @@ module.exports = {
 
   afterInstall: function(options) {
     return this.addBowerPackagesToProject([
-                  {name:'i18next-xhr-backend', target:'^0.6.0'},
-                  {name:'i18next', target:'^3.3.1'}
-                ]);
+      {name:'i18next-xhr-backend', target:'^0.6.0'},
+      {name:'i18next', target:'^3.3.1'}
+    ]);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,10 @@
     "ember-qunit": "0.4.18",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "i18next": "^1.7.0",
+    "i18next": "^3.3.1",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
+    "qunit": "~1.18.0",
+    "i18next-xhr-backend": "^0.6.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
   name: 'ember-i18next',
   included: function (app) {
     app.import('bower_components/i18next/i18next.js');
+    app.import('bower_components/i18next-xhr-backend/i18nextXHRBackend.js');
   }
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -14,16 +14,15 @@ module.exports = function(environment) {
     },
     defaultLocale: 'en',
     i18nextOptions: {
-      ns: {
-        namespaces: [ 'main' ],
-        defaultNs: 'main'
-      },
+      ns: [ 'main' ],
+      defaultNS: 'main',
       useCookie: false,
-      preload: [ 'en' ],
+      preload: [ 'en', 'th' ],
       lng: 'en',
       fallbackLng: 'en',
-      getAsync: true,
-      resGetPath: '/locales/__ns__/__lng__.json',
+      backend: {
+        loadPath: 'locales/{{ns}}/{{lng}}.json'
+      },
       debug: true
     },
 

--- a/tests/dummy/public/locales/main/en.json
+++ b/tests/dummy/public/locales/main/en.json
@@ -1,5 +1,5 @@
 {
 	"test": "test output",
-	"testarg": "__count__ frog",
-	"testarg_plural": "__count__ frogs"
+	"testarg": "{{count}} frog",
+	"testarg_plural": "{{count}} frogs"
 }

--- a/tests/dummy/public/locales/main/th.json
+++ b/tests/dummy/public/locales/main/th.json
@@ -1,5 +1,5 @@
 {
 	"test": "thai test output",
-	"testarg": "thai __count__ frog",
-	"testarg_plural": "thai __count__ frogs"
+	"testarg": "thai {{count}} frog",
+	"testarg_plural": "thai {{count}} frogs"
 }


### PR DESCRIPTION
#### What's this PR do? 
ember-i18next was using v1.7, this brings it up to v3.3.

Also changes service API to match the new i18next v3 API.

#### Info:
* The i18next API has changed so this PR will introduce breaking changes, a major version bump is required.
* i18next has introduced a plugin architecture via the ``use()`` API.  This PR doesn't completely address this.  It assumes that ember apps will be loading their catalogs via XHR and  brings in the ``i18next-xhr-backend`` by default.  Going forward it would be nice to have a way to control what plugins are loaded.