### PR TITLE
Allow Markup in I18N Keys

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -21,7 +21,7 @@ export default Ember.Helper.extend({
    */
   compute(params, hash) {
     var path = params.shift();
-    return this.get('i18n').t(path, hash);
+    return Ember.String.htmlSafe(this.get('i18n').t(path, hash));
   },
 
   refreshText: Ember.observer('i18n._locale', function () {

--- a/tests/acceptance/translation-test.js
+++ b/tests/acceptance/translation-test.js
@@ -56,3 +56,14 @@ test('Changing bound params changes text', function(assert) {
     assert.equal(find('div#translated-with-bound-args').text(), '5000 frogs');
   });
 });
+
+test('Markup is allowed in translation keys but substitutions are escaped', function(assert) {
+  visit('/');
+  click('a#change-language-en');
+
+  andThen(function() {
+    assert.equal(find('div#translated-with-markup b').length, 1, 'there should be a bold tag');
+    assert.equal(find('div#translated-with-markup-malicious script').length, 0,
+      '<script> tag in content should be escaped and not be rendered');
+  });
+});

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,6 +3,8 @@
 <div id="translated-with-args1">{{t "testarg" count=1}}</div>
 <div id="translated-with-args3">{{t "testarg" count=3}}</div>
 <div id="translated-with-bound-args">{{t "testarg" count=model.count}}</div>
+<div id="translated-with-markup">{{t "test_with_markup" content="bold stuff"}}</div>
+<div id="translated-with-markup-malicious">{{t "test_with_markup" content='<script src="evil.js"/>'}}</div>
 <div><a id="change-language-en" href="#" {{action 'changeLanguage' 'en'}}>Use English</a></div>
 <div><a id="change-language-th" href="#" {{action 'changeLanguage''th'}}>Use Thai</a></div>
 <div><a id="change-count-1000" href="#" {{action 'changeCount' 1000}}>Set Count = 1000</a></div>

--- a/tests/dummy/public/locales/main/en.json
+++ b/tests/dummy/public/locales/main/en.json
@@ -1,5 +1,6 @@
 {
 	"test": "test output",
 	"testarg": "{{count}} frog",
-	"testarg_plural": "{{count}} frogs"
+	"testarg_plural": "{{count}} frogs",
+  "test_with_markup": "<b>{{content}}</b>"
 }

--- a/tests/dummy/public/locales/main/th.json
+++ b/tests/dummy/public/locales/main/th.json
@@ -1,5 +1,6 @@
 {
 	"test": "thai test output",
 	"testarg": "thai {{count}} frog",
-	"testarg_plural": "thai {{count}} frogs"
+	"testarg_plural": "thai {{count}} frogs",
+  "test_with_markup": "thai <b>{{content}}</b>"
 }


### PR DESCRIPTION
Allow the `{{t}}` helper to render markup included in I18N keys by returning a safe string. i18next will still escape substitutions unless escaping is specifically disabled.