### PR TITLE
Convert to ES2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ export default Ember.Component.extend({
   messages: someObject,
 
   messageCount: Ember.computed('messages', function () {
-    var i18n = this.get('i18n');
-    var count = this.get('messages.count');
+    const i18n = this.get('i18n');
+    const count = this.get('messages.count');
     return i18n.t('messages.count', { msgCount: count });
   }
 });
@@ -111,7 +111,7 @@ export default Ember.Component.extend(I18nMixin, {
   messages: someObject,
 
   messageCount: Ember.computed('messages', function () {
-    var count = this.get('messages.count');
+    const count = this.get('messages.count');
     return this.t('messages.count', { msgCount: count })
   });
 });
@@ -141,7 +141,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend(I18nMixin, {
   actions: {
-    gimmeThai: function () {
+    gimmeThai() {
       this.set('i18n.locale', 'th-TH');
     }
   }
@@ -157,12 +157,12 @@ import Ember from 'ember';
 import I18nMixin from '../mixins/i18n';
 
 export default Ember.Route.extend(I18nMixin, {
-  init: function () {
+  init() {
     this._super();
-    var i18n = this.get('i18n');
+    const i18n = this.get('i18n');
 
     // my-fancy-action is a name that can be used to unregister the action later
-    i18n.registerPostInitAction('my-fancy-action', function (oldLang) {
+    i18n.registerPostInitAction('my-fancy-action', oldLang => {
       // do preloading
     });
   }

--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -20,7 +20,7 @@ export default Ember.Helper.extend({
    * @return {String} text localized for the current locale.
    */
   compute(params, hash) {
-    var path = params.shift();
+    const path = params.shift();
     return Ember.String.htmlSafe(this.get('i18n').t(path, hash));
   },
 

--- a/app/mixins/i18n.js
+++ b/app/mixins/i18n.js
@@ -9,10 +9,10 @@ import Ember from 'ember';
  *   convenience.
  * @see services/i18n
  */
-var I18nMixin = Ember.Mixin.create({
+const I18nMixin = Ember.Mixin.create({
   i18n: Ember.inject.service(),
 
-  t: function (path, values) {
+  t(path, values) {
     return this.get('i18n').t(path, values);
   }
 });

--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -60,7 +60,7 @@ const I18nService = Ember.Service.extend({
       this.set('locale', i18next.language);
       this.set('isInitialized', true);
     }).catch(reason => {
-      Ember.warn('A promise in the i18next init chain rejected with value: ' + reason);
+      Ember.Logger.warn(`A promise in the i18next init chain rejected with reason: ${reason}`);
     });
   },
 
@@ -151,7 +151,7 @@ const I18nService = Ember.Service.extend({
     }).then(() => {
       return Ember.RSVP.resolve(lang);
     }).catch(reason => {
-      Ember.warn('A promise in the locale change path rejected: ' + reason);
+      Ember.Logger.warn(`A promise in the locale change path rejected with reason: ${reason}`);
     });
   },
 

--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -4,7 +4,7 @@ import config from '../config/environment';
 /**
  * A service that exposes functionality from i18next.
  */
-var I18nService = Ember.Service.extend({
+const I18nService = Ember.Service.extend({
   i18next: null,
   isInitialized: false,
 
@@ -12,7 +12,7 @@ var I18nService = Ember.Service.extend({
   _preInitActions: {},
   _postInitActions: {},
 
-  init: function () {
+  init() {
     Ember.assert(window.i18next, 'i18next was not found. Check your bower.json file to make sure it is loaded.');
     Ember.assert(window.i18nextXHRBackend, 'i18nextXHRBackend was not found. Check your bower.json file to make sure it is loaded.');
     this.set('i18next', window.i18next);
@@ -29,12 +29,11 @@ var I18nService = Ember.Service.extend({
       return this.get('_locale');
     },
     set(key, value) {
-      var lang = value;
-      var self = this;
+      const lang = value;
 
       if (this.get('isInitialized')) {
-        this._changeLocale(lang).then(function (lang) {
-          self.set('_locale', lang);
+        this._changeLocale(lang).then(lang => {
+          this.set('_locale', lang);
         });
       } else {
         this.set('_locale', lang);
@@ -50,18 +49,17 @@ var I18nService = Ember.Service.extend({
    * @return {Promise} - a promise that resolves with the i18next object when
    *   i18next has finished initializing.
    */
-  initLibraryAsync: function () {
-    var i18next = this.get('i18next');
-    var self = this;
+  initLibraryAsync() {
+    const i18next = this.get('i18next');
 
-    return this._runPreInitActions().then(function () {
-      return self._initLibrary();
-    }).then(function () {
-      self._runPostInitActions();
-    }).then(function () {
-      self.set('locale', i18next.language);
-      self.set('isInitialized', true);
-    }).catch(function (reason) {
+    return this._runPreInitActions().then(() => {
+      return this._initLibrary();
+    }).then(() => {
+      this._runPostInitActions();
+    }).then(() => {
+      this.set('locale', i18next.language);
+      this.set('isInitialized', true);
+    }).catch(reason => {
       Ember.warn('A promise in the i18next init chain rejected with value: ' + reason);
     });
   },
@@ -79,7 +77,7 @@ var I18nService = Ember.Service.extend({
    * @param {Function} fn - a zero-argument callback function. Return a promise if
    *   the operation needs to complete before the i18next is initialized.
    */
-  registerPreInitAction: function (key, fn) {
+  registerPreInitAction(key, fn) {
     Ember.assert('Pre-init action key may not be blank', !Ember.isBlank(key));
     Ember.assert('A pre-init action must be a function', typeof fn === 'function');
     this.get('_preInitActions')[key] = fn;
@@ -91,9 +89,9 @@ var I18nService = Ember.Service.extend({
    * @param {String|Object} key - the key to use to look up the action to remove.
    *   May not be blank.
    */
-  unregisterPreInitAction: function (key) {
+  unregisterPreInitAction(key) {
     Ember.assert('Action key may not be blank', !Ember.isBlank(key));
-    var preInitActions = this.get('_preInitActions');
+    const preInitActions = this.get('_preInitActions');
 
     delete preInitActions[key];
   },
@@ -111,7 +109,7 @@ var I18nService = Ember.Service.extend({
    * @param {Function} fn - a zero-argument callback function. Return a promise if
    *   the operation needs to complete before the the UI is refreshed.
    */
-  registerPostInitAction: function (name, fn) {
+  registerPostInitAction(name, fn) {
     Ember.assert('Pre-init action name may not be blank', !Ember.isBlank(name));
     Ember.assert('A post-init action must be a function', typeof fn === 'function');
     this.get('_postInitActions')[name] = fn;
@@ -123,9 +121,9 @@ var I18nService = Ember.Service.extend({
    * @param {String|Object} key - the key to use to look up the action to remove.
    *   May not be blank.
    */
-  unregisterPostInitAction: function (key) {
+  unregisterPostInitAction(key) {
     Ember.assert('Action key may not be blank', !Ember.isBlank(key));
-    var postInitActions = this.get('_postInitActions');
+    const postInitActions = this.get('_postInitActions');
 
     delete postInitActions[key];
   },
@@ -138,22 +136,21 @@ var I18nService = Ember.Service.extend({
    *
    * @return {Promise} a promise that resolves with the language code when complete.
    */
-  _changeLocale: function (lang) {
-    var i18next = this.get('i18next');
+  _changeLocale(lang) {
+    const i18next = this.get('i18next');
 
     if (i18next && lang && i18next.language === lang) {
       return Ember.RSVP.resolve(lang);
     }
 
-    var self = this;
-    var oldLang = this._locale;
-    return this._runPreInitActions(lang).then(function () {
-      return self._setLng(lang);
-    }).then(function () {
-      return self._runPostInitActions(oldLang);
-    }).then(function () {
+    const oldLang = this._locale;
+    return this._runPreInitActions(lang).then(() => {
+      return this._setLng(lang);
+    }).then(() => {
+      return this._runPostInitActions(oldLang);
+    }).then(() => {
       return Ember.RSVP.resolve(lang);
-    }).catch(function (reason) {
+    }).catch(reason => {
       Ember.warn('A promise in the locale change path rejected: ' + reason);
     });
   },
@@ -168,78 +165,78 @@ var I18nService = Ember.Service.extend({
    *
    * @return Localized text.
    */
-  t: function(path, values) {
-    var i18next = this.get('i18next');
+  t(path, values) {
+    const i18next = this.get('i18next');
     return i18next.t(path, values);
   },
 
   /**
    * Forwarded to `i18next.addResourceBundle()`.
    */
-  addResourceBundle: function (lang, ns, resources, deep, overwrite) {
+  addResourceBundle(lang, ns, resources, deep, overwrite) {
     return this.get('i18next').addResourceBundle(lang, ns, resources, deep, overwrite);
   },
 
   /**
    * Forwarded to `i18next.hasResourceBundle()`.
    */
-  hasResourceBundle: function (lang, ns) {
+  hasResourceBundle(lang, ns) {
     return this.get('i18next').hasResourceBundle(lang, ns);
   },
 
   /**
    * Forwarded to `i18next.getResourceBundle()`.
    */
-  getResourceBundle: function (lang, ns) {
+  getResourceBundle(lang, ns) {
     return this.get('i18next').getResourceBundle(lang, ns);
   },
 
   /**
    * Forwarded to `i18next.removeResourceBundle()`.
    */
-  removeResourceBundle: function (lang, ns) {
+  removeResourceBundle(lang, ns) {
     return this.get('i18next').removeResourceBundle(lang, ns);
   },
 
   /**
    * Forwarded to `i18next.addResource()`.
    */
-  addResource: function (lang, ns, key, value, options) {
+  addResource(lang, ns, key, value, options) {
     return this.get('i18next').addResource(lang, ns, key, value, options);
   },
 
   /**
    * Forwarded to `i18next.addResources()`.
    */
-  addResources: function (lang, ns, resources) {
+  addResources(lang, ns, resources) {
     return this.get('i18next').addResources(lang, ns, resources);
   },
 
   /**
    * Forwarded to `i18next.loadNamespaces()`.
    */
-  loadNamespaces: function (namespaces, callback) {
+  loadNamespaces(namespaces, callback) {
     return this.get('i18next').loadNamespaces(namespaces, callback);
   },
 
   /**
    * Forwarded to `i18next.setDefaultNamespace()`.
    */
-  setDefaultNamespace: function (ns) {
+  setDefaultNamespace(ns) {
     return this.get('i18next').setDefaultNamespace(ns);
   },
 
   /**
    * Alias for `t()`.
    */
-  translate: function (key, values) {
+  translate(key, values) {
     return this.t(key, values);
   },
 
   /**
    * Forwarded to `i18next.exists()`.
    */
-  exists: function (key, options) {
+  exists(key, options) {
     return this.get('i18next').exists(key, options);
   },
 
@@ -253,23 +250,21 @@ var I18nService = Ember.Service.extend({
   /**
    * Forwarded to `i18next.addPostProcessor()`.
    */
-  addPostProcessor: function (name, fn) {
+  addPostProcessor(name, fn) {
     return this.get('i18next').addPostProcessor(name, fn);
   },
 
   /**
    * Forwarded to `i18next.applyReplacement()`.
    */
-  applyReplacement: function (str, replacementHash, nestedKey, options) {
+  applyReplacement(str, replacementHash, nestedKey, options) {
     return this.get('i18next').applyReplacement(str, replacementHash, nestedKey, options);
   },
 
-  _initLibrary: function () {
-    var self = this;
-
-    return new Ember.RSVP.Promise(function (resolve, reject) {
-      var i18next = self.get('i18next');
-      var options = config.i18nextOptions || {};
+  _initLibrary() {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      const i18next = this.get('i18next');
+      const options = config.i18nextOptions || {};
 
       //
       //  TODO:  Adding i18nextXHRBackend by default so that translation
@@ -279,7 +274,7 @@ var I18nService = Ember.Service.extend({
       //
       i18next
         .use(window.i18nextXHRBackend)
-        .init(options, (err, t) => {
+        .init(options, (err) => {
          if (err) {
            reject(err);
          } else {
@@ -289,36 +284,36 @@ var I18nService = Ember.Service.extend({
     });
   },
 
-  _setLng: function (locale) {
-    var i18next = this.get('i18next');
+  _setLng(locale) {
+    const i18next = this.get('i18next');
 
-    return new Ember.RSVP.Promise(function (resolve) {
-      i18next.changeLanguage(locale, function () {
+    return new Ember.RSVP.Promise(resolve => {
+      i18next.changeLanguage(locale, () => {
         resolve(locale);
       });
     });
   },
 
-  _getActionCallHash: function (actions, lang) {
-    var actionsCallHash = {};
+  _getActionCallHash(actions, lang) {
+    const actionsCallHash = {};
 
-    Object.keys(actions).forEach(function (key) {
+    Object.keys(actions).forEach(key => {
       actionsCallHash[key] = actions[key].call(undefined, lang);
     });
 
     return actionsCallHash;
   },
 
-  _runPreInitActions: function (newLang) {
-    var _preInitActions = this.get('_preInitActions');
-    var actionCalls = this._getActionCallHash(_preInitActions, newLang);
+  _runPreInitActions(newLang) {
+    const _preInitActions = this.get('_preInitActions');
+    const actionCalls = this._getActionCallHash(_preInitActions, newLang);
 
     return Ember.RSVP.hash(actionCalls, 'ember-i18next: pre init actions');
   },
 
-  _runPostInitActions: function (oldLang) {
-    var _postInitActions = this.get('_postInitActions');
-    var actionCalls = this._getActionCallHash(_postInitActions, oldLang);
+  _runPostInitActions(oldLang) {
+    const _postInitActions = this.get('_postInitActions');
+    const actionCalls = this._getActionCallHash(_postInitActions, oldLang);
 
     return Ember.RSVP.hash(actionCalls, 'ember-i18next: post init actions');
   }

--- a/tests/acceptance/mixin-test.js
+++ b/tests/acceptance/mixin-test.js
@@ -19,10 +19,10 @@ function testTranslations (assert, subject) {
 }
 
 module('Acceptance: Mixin', {
-  beforeEach: function() {
+  beforeEach() {
     application = startApp();
   },
-  afterEach: function() {
+  afterEach() {
     Ember.run(application, 'destroy');
   }
 });
@@ -30,7 +30,7 @@ module('Acceptance: Mixin', {
 test('routes with mixin can translate', function(assert) {
   visit('/');
 
-  andThen(function() {
+  andThen(() => {
     var indexRoute = lookup('route:index');
     assert.ok(indexRoute);
     testTranslations(assert, indexRoute);
@@ -40,7 +40,7 @@ test('routes with mixin can translate', function(assert) {
 test('controllers with mixin can translate', function(assert) {
   visit('/');
 
-  andThen(function () {
+  andThen(() => {
     var controller = lookup('controller:index');
     assert.ok(controller);
     testTranslations(assert, controller);
@@ -50,7 +50,7 @@ test('controllers with mixin can translate', function(assert) {
 test('components with mixin can translate', function(assert) {
   visit('/');
 
-  andThen(function () {
+  andThen(() => {
     var component = lookup('component:t-component');
     assert.ok(component);
     testTranslations(assert, component);

--- a/tests/acceptance/service-locale-change-actions-test.js
+++ b/tests/acceptance/service-locale-change-actions-test.js
@@ -8,13 +8,13 @@ import startApp from '../helpers/start-app';
 var application, container, service;
 
 module('Acceptance: ServiceLocaleChangeActions', {
-  beforeEach: function() {
+  beforeEach() {
     application = startApp();
     container = application.__container__;
     service = container.lookup('service:i18n');
   },
 
-  afterEach: function() {
+  afterEach() {
     Ember.run(application, 'destroy');
   }
 });
@@ -25,8 +25,8 @@ test('setting language triggers pre-init actions', function (assert) {
   visit('/');
   click('a#change-language-en');
 
-  andThen(function() {
-    service.registerPreInitAction('test-pre-init', function (newLang) {
+  andThen(() => {
+    service.registerPreInitAction('test-pre-init', newLang => {
       assert.ok(true, 'Setting locale triggers pre-init action');
       assert.strictEqual(newLang, 'th', 'Pre-init\'s newLang is "th"');
     });
@@ -41,8 +41,8 @@ test('setting language triggers post-init actions', function (assert) {
   visit('/');
   click('a#change-language-en');
 
-  andThen(function () {
-    service.registerPostInitAction('test-post-init', function (oldLang) {
+  andThen(() => {
+    service.registerPostInitAction('test-post-init', oldLang => {
       assert.ok(true, 'Setting locale triggers post-init action');
       assert.strictEqual(oldLang, 'en', 'Post-init\'s oldLang is "en"');
     });
@@ -57,13 +57,13 @@ test('unregistering pre-init actions', function (assert) {
   visit('/');
   click('a#change-language-en');
 
-  andThen(function() {
-    service.registerPreInitAction('removed-pre-init', function () {
+  andThen(() => {
+    service.registerPreInitAction('removed-pre-init', () => {
       // should not get here
       assert.ok(false, 'Setting locale should not trigger unregistered actions');
     });
 
-    service.registerPreInitAction('test-pre-init', function () {
+    service.registerPreInitAction('test-pre-init', () => {
       assert.ok(true, 'Setting locale should triggered pre-init actions');
     });
 
@@ -79,13 +79,13 @@ test('unregistering post-init actions', function (assert) {
   visit('/');
   click('a#change-language-en');
 
-  andThen(function () {
-    service.registerPostInitAction('removed-post-init', function () {
+  andThen(() => {
+    service.registerPostInitAction('removed-post-init', () => {
       // should not get here
       assert.ok(false, 'Setting locale should not trigger unregistered actions');
     });
 
-    service.registerPostInitAction('test-post-init', function () {
+    service.registerPostInitAction('test-post-init', () => {
       assert.ok(true, 'Setting locale should trigger post-init actions.');
     });
 

--- a/tests/acceptance/translation-test.js
+++ b/tests/acceptance/translation-test.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import {module, test} from 'qunit';
 import startApp from '../helpers/start-app';
 
-var application;
+let application;
 
 module('Acceptance: Translation', {
-  beforeEach: function() {
+  beforeEach() {
     application = startApp();
   },
-  afterEach: function() {
+  afterEach() {
     Ember.run(application, 'destroy');
   }
 });
@@ -18,7 +18,7 @@ test('English translations are correct', function(assert) {
   click('a#change-language-en');
   click('a#change-count-1000');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(find('div#translated').text(), 'test output');
     assert.equal(find('div#translated-with-args0').text(), '0 frogs');
     assert.equal(find('div#translated-with-args1').text(), '1 frog');
@@ -32,7 +32,7 @@ test('Changing locale changes text', function(assert) {
   click('a#change-language-th');
   click('a#change-count-1000');
 
-  andThen(function () {
+  andThen(() => {
     assert.equal(find('div#translated').text(), 'thai test output');
     assert.equal(find('div#translated-with-args0').text(), 'thai 0 frog');
     assert.equal(find('div#translated-with-args1').text(), 'thai 1 frog');
@@ -46,13 +46,13 @@ test('Changing bound params changes text', function(assert) {
   click('a#change-language-en');
   click('a#change-count-1000');
 
-  andThen(function () {
+  andThen(() => {
     assert.equal(find('div#translated-with-bound-args').text(), '1000 frogs');
   });
 
   click('a#change-count-5000');
 
-  andThen(function () {
+  andThen(() => {
     assert.equal(find('div#translated-with-bound-args').text(), '5000 frogs');
   });
 });
@@ -61,7 +61,7 @@ test('Markup is allowed in translation keys but substitutions are escaped', func
   visit('/');
   click('a#change-language-en');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(find('div#translated-with-markup b').length, 1, 'there should be a bold tag');
     assert.equal(find('div#translated-with-markup-malicious script').length, 0,
       '<script> tag in content should be escaped and not be rendered');

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,7 +3,7 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-var App;
+let App;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+let Router = Ember.Router.extend({
   location: config.locationType
 });
 

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -4,22 +4,22 @@ import I18nMixin from '../mixins/i18n';
 export default Ember.Route.extend(I18nMixin, {
   countObj: Ember.Object.create({ count: 1000 }),
 
-  beforeModel: function () {
-    var i18next = this.get('i18n');
+  beforeModel() {
+    const i18next = this.get('i18n');
     return i18next.initLibraryAsync();
   },
 
-  model: function () {
+  model() {
     return this.get('countObj');
   },
 
   actions: {
-    changeLanguage: function (lang) {
-      var service = this.get('i18n');
+    changeLanguage(lang) {
+      const service = this.get('i18n');
       service.set('locale', lang);
     },
 
-    changeCount: function (count) {
+    changeCount(count) {
       this.get('countObj').set('count', count);
     }
   }

--- a/tests/dummy/app/routes/test-init.js
+++ b/tests/dummy/app/routes/test-init.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import I18nMixin from '../mixins/i18n';
 
 export default Ember.Route.extend(I18nMixin, {
-  beforeModel: function () {
-    var i18next = this.get('i18n');
+  beforeModel() {
+    const i18next = this.get('i18n');
     return i18next.initLibraryAsync();
   }
 });

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
 import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+let resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -4,9 +4,9 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var application;
+  let application;
 
-  var attributes = Ember.merge({}, config.APP);
+  let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {

--- a/tests/unit/mixins/i18n-test.js
+++ b/tests/unit/mixins/i18n-test.js
@@ -5,20 +5,20 @@ import { module, test } from 'qunit';
 module('I18nMixin');
 
 test('it works', function (assert) {
-  var I18nObject = Ember.Object.extend(I18nMixin);
-  var subject = I18nObject.create();
+  const I18nObject = Ember.Object.extend(I18nMixin);
+  const subject = I18nObject.create();
   assert.ok(subject);
 });
 
 test('it adds an i18n property', function (assert) {
-  var I18nObject = Ember.Object.extend(I18nMixin);
-  var subject = I18nObject.create();
+  const I18nObject = Ember.Object.extend(I18nMixin);
+  const subject = I18nObject.create();
   assert.ok('i18n' in subject);
 });
 
 test('it adds a t function', function (assert) {
-  var I18nObject = Ember.Object.extend(I18nMixin);
-  var subject = I18nObject.create();
+  const I18nObject = Ember.Object.extend(I18nMixin);
+  const subject = I18nObject.create();
   assert.ok('t' in subject);
   assert.equal(typeof subject.t, 'function');
 });

--- a/tests/unit/services/i18n-test.js
+++ b/tests/unit/services/i18n-test.js
@@ -9,12 +9,12 @@ moduleFor('service:i18n', {
 });
 
 test('it exists', function(assert) {
-  var service = this.subject();
+  const service = this.subject();
   assert.ok(service);
 });
 
 test('throws when action names are blank', function (assert) {
-  var service = this.subject();
+  const service = this.subject();
 
   assert.throws(function () { service.registerPreInitAction('', function () {}); },
     'Throws if registered pre-init action name is blank.');
@@ -27,7 +27,7 @@ test('throws when action names are blank', function (assert) {
 });
 
 test('throws when actions are not functions', function (assert) {
-  var service = this.subject();
+  const service = this.subject();
 
   assert.throws(function () { service.registerPreInitAction('woo', 'woo'); },
    'Throws if pre-init action is not a function.');


### PR DESCRIPTION
Fixes #29.

* use `let` and `const` instead of `var`
* use arrow functions (esp. in promise chains)
* use shorter object literal syntax for methods