### PR TITLE
Don't Modify Helper Arguments

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -20,7 +20,7 @@ export default Ember.Helper.extend({
    * @return {String} text localized for the current locale.
    */
   compute(params, hash) {
-    const path = params.shift();
+    const path = params[0];
     return Ember.String.htmlSafe(this.get('i18n').t(path, hash));
   },
 


### PR DESCRIPTION
Update the `t` helper so it does not `shift` the first argument off of the `params` argument. Ember 2.9 seals this array so it cannot be modified, so the call to `shift` causes an exception. Simply extract the first argument (the translation key) using array access.

Fixes #40.