### PR TITLE
Manage i18next's option "returnObjects" in helper

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -17,11 +17,13 @@ export default Ember.Helper.extend({
    * @param {Object} hash - an object containing the hash parameters passed to the
    *   helper. Used for translation substitutions.
    *
-   * @return {String} text localized for the current locale.
+   * @return {*} text localized for the current locale.
    */
   compute(params, hash) {
     const path = params[0];
-    return Ember.String.htmlSafe(this.get('i18n').t(path, hash));
+    const res = this.get('i18n').t(path, hash);
+
+    return hash.returnObjects ? res : Ember.String.htmlSafe(res);
   },
 
   refreshText: Ember.observer('i18n._locale', function () {


### PR DESCRIPTION
Hello,

When we use i18next's option `returnObjects` with `t` helper, it return a HTML safe string.

We should test `hash.returnObjects`and return a string or the result of `i18n.t` function according to the value of this option.