### PR TITLE
Fix Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,26 @@ node_js:
   - "6"
 
 sudo: false
+dist: trusty
 
-cache:
-  directories:
-    - $HOME/.npm
+addons:
+  chrome: stable
+
+cache: yarn
 
 env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-2.12
+  - EMBER_TRY_SCENARIO=ember-2.18
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
-before_install:
-  - npm config set spin false
-  - npm install -g phantomjs-prebuilt
-  - phantomjs --version
-
 install:
-  - npm install
+  - yarn
 
 script:
-  - ember try:one $EMBER_TRY_SCENARIO
+  - ember try:one $EMBER_TRY_SCENARIO --- ember test -c testem-travis.js

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,62 +1,83 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-release',
-      dependencies: {
-        'ember': 'components/ember#release'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
       },
-      resolutions: {
-        'ember': 'release'
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
       name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#beta'
+        },
+        resolutions: {
+          'ember': 'beta'
+        }
       },
-      resolutions: {
-        'ember': 'beta'
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
       name: 'ember-canary',
       allowedToFail: true,
-      dependencies: {
-        'ember': 'components/ember#canary'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
       },
-      resolutions: {
-        'ember': 'canary'
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
       name: 'ember-1.13',
-      dependencies: {
-        'ember': '1.13.11'
+      bower: {
+        dependencies: {
+          'ember': '1.13.11'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
-      name: 'ember-2.0',
-      dependencies: {
-        'ember': '2.0.2'
+      name: 'ember-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0'
+        }
       }
     },
     {
-      name: 'ember-2.4',
-      dependencies: {
-        'ember': '~2.4.0'
-      }
-    },
-    {
-      name: 'ember-2.8',
-      dependencies: {
-        'ember': '~2.8.0'
-      }
-    },
-    {
-      name: 'ember-2.12',
-      dependencies: {
-        'ember': '~2.12.0'
+      name: 'ember-2.18',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.18.0'
+        }
       }
     }
   ]

--- a/testem-travis.js
+++ b/testem-travis.js
@@ -12,6 +12,7 @@ module.exports = {
     Chrome: {
       mode: 'ci',
       args: [
+        '--no-sandbox',
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',


### PR DESCRIPTION
* Update ember-try config format to distinguish npm and bower packages (fixes tests of release and 2.18 LTS)
* Use headless Chrome to run tests (fixes tests for beta and canary)
* Separate testem config for Travis