### PR TITLE
Upgrade i18next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7334,14 +7334,17 @@
       }
     },
     "i18next": {
-      "version": "11.10.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-11.10.2.tgz",
-      "integrity": "sha512-1rowdX8PqrvsdFhYb3v0A/LlIHLQL1HTa4ia29IzhvNAg2fesNV7R1jXibWLmLQdz3FfTB8RuqSqDEjIawXruA=="
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.7.tgz",
+      "integrity": "sha512-KCSmTOE0nsku53cI0sSBY21ftXhsAfCjcNQBx54Y0AxcTxSs+v+qGFQ38ab+vi6F4NZEm8JupO36vlWoeF47cA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
     },
     "i18next-xhr-backend": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-1.5.1.tgz",
-      "integrity": "sha512-9OLdC/9YxDvTFcgsH5t2BHCODHEotHCa6h7Ly0EUlUC7Y2GS09UeoHOGj3gWKQ3HCqXz8NlH4gOrK3NNc9vPuw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-2.0.1.tgz",
+      "integrity": "sha512-CP0XPjJsTE4hY1rM1KXFYo63Ib61EBLEcTvMDyJwr0vs9p/UTuA3ENCmzSs9+ghZgWSjdOigc0oUERHaxctbsQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^7.1.2",
-    "i18next": "^11.10.0",
-    "i18next-xhr-backend": "^1.5.1"
+    "i18next": "^15.0.7",
+    "i18next-xhr-backend": "^2.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",


### PR DESCRIPTION
Upgrade to the latest i18next and i18next-xhr-backend releases.

A [bug about plural rule for JSON compatibility v2 was introduced in 11.3.3](https://github.com/i18next/i18next/issues/1069) and [fixed in 13.1.4](https://github.com/i18next/i18next/commit/d4d329fd7042f932eedf8bba1d92234707efd04c#diff-e171f9b8b4e0f5df027bd8bd7b962f1bR1140).