### PR TITLE
Update Version of Node Used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
Update the version of Node used by Travis, since Node 6 is end of life and recent Ember releases only support Node 8.x and higher.