### PR TITLE
Configure Dependabot Merging

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+    - "dependencies"
+    automerged_updates:
+    - match:
+        dependency_type: "development"
+        update_type: "semver:minor"
+    - match:
+        dependency_type: "production"
+        update_type: "semver:patch"


### PR DESCRIPTION
Configure Dependabot to automatically merge patch version updates for production dependencies and minor version development dependencies to match other repositories.