### PR TITLE
Disable Scheduled CI Run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
       - master
       - "v*"
   pull_request: {}
-  schedule:
-    # run tests daily at 13:19 UTC
-    - cron: '19 13 * * *'
 
 jobs:
   lint:


### PR DESCRIPTION
Disable the daily scheduled CI run, which is currently failing most days without appearing to ever start. It is also starting an unexpected number of jobs ([see this run for example](https://github.com/OCTRI/ember-i18next/actions/runs/78923978), which started 27 jobs instead of the expected 9). Tests still run on branch pushes and pull requests.