### PR TITLE
Exclude CI and Dependabot Config From Package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,12 +7,14 @@
 
 # misc
 /.bowerrc
+/.dependabot/
 /.editorconfig
 /.ember-cli
 /.env*
 /.eslintignore
 /.eslintrc.js
 /.git/
+/.github/
 /.gitignore
 /.template-lintrc.js
 /.travis.yml


### PR DESCRIPTION
Update `.npmignore` file to exclude GitHub Actions and Dependabot configuration from the npm package.