### PR TITLE
Import `htmlSafe` from `@ember/template`

### DIFF
--- a/addon/helpers/t.js
+++ b/addon/helpers/t.js
@@ -1,5 +1,5 @@
 import { observer } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { inject as service } from '@ember/service';
 import Helper from '@ember/component/helper';
 


### PR DESCRIPTION
Import `htmlSafe` from `@ember/template` instead of `@ember/string`. Fixes #518.